### PR TITLE
Add macOS desktop simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# desktop-simulator
+# macOS Sonoma Desktop Simulator
+
+This project provides a simple, pure HTML/CSS/JavaScript simulation of the macOS Sonoma desktop interface.
+
+## Features
+- Desktop with wallpaper and draggable icons.
+- Menu bar with Apple menu, status icons and clock.
+- Dock with magnification effect when hovering icons.
+- Basic windows with draggable title bars and close/minimize/maximize buttons.
+- Spotlight, Control Center and Notification Center overlays.
+- Sample application windows launched from the dock.
+
+Everything is implemented without any JavaScript frameworks. Only standard web technologies are used.
+
+## Running
+Simply open `index.html` in Chrome or Safari. No build step is required.
+
+## Usage
+- Click the  icon to open the Apple menu. Choose **About This Mac** to show system information.
+- Use the Dock icons to open simple demo windows.
+- Click the Spotlight icon to open a search field.
+- Click the Control Center icon to toggle quick controls.
+- Click the clock to open the Notification Center.
+- Drag desktop icons to rearrange them.
+
+## Assets
+All visual elements are represented with emoji or CSS for simplicity. Feel free to replace them with your own images inside the `assets/` directory and update the HTML/CSS accordingly.
+
+## License
+This project is provided for educational purposes only and is not affiliated with Apple Inc.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>macOS Sonoma Simulator</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="desktop">
+        <div id="menu-bar">
+            <div id="apple" class="menu-item"></div>
+            <div id="app-menu" class="menu-item">Finder</div>
+            <div id="menu-items" class="menu-item">
+                <span>File</span>
+                <span>Edit</span>
+                <span>View</span>
+                <span>Go</span>
+                <span>Window</span>
+                <span>Help</span>
+            </div>
+            <div id="status-items">
+                <span id="wifi" class="status-icon">📶</span>
+                <span id="bluetooth" class="status-icon">🅱️</span>
+                <span id="battery" class="status-icon">🔋</span>
+                <span id="volume" class="status-icon">🔊</span>
+                <span id="spotlight" class="status-icon">🔍</span>
+                <span id="siri" class="status-icon">🎤</span>
+                <span id="control" class="status-icon">🕹</span>
+                <span id="clock" class="status-icon">00:00</span>
+            </div>
+        </div>
+        <div id="icons">
+            <div class="desktop-icon" draggable="true">💻<span>Macintosh HD</span></div>
+            <div class="desktop-icon" draggable="true">📁<span>Applications</span></div>
+            <div class="desktop-icon" draggable="true">📄<span>Documents</span></div>
+        </div>
+        <div id="dock">
+            <div class="dock-icon" data-app="finder">🖥</div>
+            <div class="dock-icon" data-app="safari">🌐</div>
+            <div class="dock-icon" data-app="mail">✉️</div>
+            <div class="dock-icon" data-app="messages">💬</div>
+            <div class="dock-icon" data-app="photos">🖼</div>
+            <div class="dock-icon" data-app="settings">⚙️</div>
+            <div class="dock-icon" id="trash">🗑</div>
+        </div>
+        <div id="apple-menu" class="dropdown hidden">
+            <ul>
+                <li id="about">About This Mac</li>
+                <li>System Settings...</li>
+                <li>App Store...</li>
+                <li>Recent Items</li>
+                <li>Force Quit...</li>
+                <li>Sleep</li>
+                <li>Restart...</li>
+                <li>Shut Down...</li>
+                <li>Lock Screen</li>
+                <li>Log Out...</li>
+            </ul>
+        </div>
+        <div id="about-dialog" class="window hidden">
+            <div class="title-bar">
+                <div class="control close"></div>
+                <div class="control minimize"></div>
+                <div class="control maximize"></div>
+                <span class="title">About This Mac</span>
+            </div>
+            <div class="content">
+                <p><strong>macOS Sonoma</strong></p>
+                <p>Version 14.0 (Simulated)</p>
+                <p>Processor: Virtual CPU</p>
+                <p>Memory: 4 GB</p>
+                <p>Serial Number: XXXXX</p>
+            </div>
+        </div>
+        <div id="spotlight-search" class="overlay hidden">
+            <input type="text" placeholder="Search...">
+            <div class="results"></div>
+        </div>
+        <div id="control-center" class="overlay hidden">
+            <h3>Control Center</h3>
+            <p>Wi-Fi</p>
+            <p>Bluetooth</p>
+            <p>Volume</p>
+            <p>Brightness</p>
+            <p>Do Not Disturb</p>
+        </div>
+        <div id="notification-center" class="overlay hidden">
+            <h3>Notifications</h3>
+            <p>Calendar</p>
+            <p>Weather</p>
+            <p>Notes</p>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,152 @@
+// Utility for dragging elements
+function makeDraggable(el, handle) {
+  let offsetX = 0, offsetY = 0, dragging = false;
+  handle.addEventListener('mousedown', (e) => {
+    dragging = true;
+    offsetX = e.clientX - el.offsetLeft;
+    offsetY = e.clientY - el.offsetTop;
+  });
+  document.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    el.style.left = (e.clientX - offsetX) + 'px';
+    el.style.top = (e.clientY - offsetY) + 'px';
+  });
+  document.addEventListener('mouseup', () => {
+    dragging = false;
+  });
+}
+
+// Apple menu toggle
+const appleIcon = document.getElementById('apple');
+const appleMenu = document.getElementById('apple-menu');
+appleIcon.addEventListener('click', () => {
+  appleMenu.classList.toggle('hidden');
+});
+
+document.addEventListener('click', (e) => {
+  if (!appleMenu.contains(e.target) && e.target !== appleIcon) {
+    appleMenu.classList.add('hidden');
+  }
+});
+
+// About dialog
+const aboutItem = document.getElementById('about');
+const aboutDialog = document.getElementById('about-dialog');
+aboutItem.addEventListener('click', () => {
+  appleMenu.classList.add('hidden');
+  aboutDialog.classList.remove('hidden');
+});
+
+const closeButton = aboutDialog.querySelector('.close');
+closeButton.addEventListener('click', () => {
+  aboutDialog.classList.add('hidden');
+});
+makeDraggable(aboutDialog, aboutDialog.querySelector('.title-bar'));
+
+// Spotlight
+const spotlightIcon = document.getElementById('spotlight');
+const spotlight = document.getElementById('spotlight-search');
+spotlightIcon.addEventListener('click', () => {
+  spotlight.classList.toggle('hidden');
+  spotlight.querySelector('input').focus();
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    spotlight.classList.add('hidden');
+    aboutDialog.classList.add('hidden');
+  }
+});
+
+// Control Center
+const controlIcon = document.getElementById('control');
+const controlCenter = document.getElementById('control-center');
+controlIcon.addEventListener('click', () => {
+  controlCenter.classList.toggle('hidden');
+});
+
+document.addEventListener('click', (e) => {
+  if (!controlCenter.contains(e.target) && e.target !== controlIcon) {
+    controlCenter.classList.add('hidden');
+  }
+});
+
+// Notification Center
+const clock = document.getElementById('clock');
+const notify = document.getElementById('notification-center');
+clock.addEventListener('click', () => {
+  notify.classList.toggle('hidden');
+});
+document.addEventListener('click', (e) => {
+  if (!notify.contains(e.target) && e.target !== clock) {
+    notify.classList.add('hidden');
+  }
+});
+
+// Clock update
+function updateClock() {
+  const d = new Date();
+  const h = d.getHours().toString().padStart(2,'0');
+  const m = d.getMinutes().toString().padStart(2,'0');
+  clock.textContent = `${h}:${m}`;
+}
+setInterval(updateClock, 1000);
+updateClock();
+
+// Dock click to open a sample window
+const dockIcons = document.querySelectorAll('.dock-icon[data-app]');
+let windowCount = 0;
+dockIcons.forEach(icon => {
+  icon.addEventListener('click', () => {
+    const win = createWindow(icon.dataset.app);
+    document.getElementById('desktop').appendChild(win);
+  });
+});
+
+function createWindow(appName) {
+  const win = document.createElement('div');
+  win.className = 'window';
+  win.style.top = (150 + windowCount * 20) + 'px';
+  win.style.left = (150 + windowCount * 20) + 'px';
+  windowCount++;
+  win.innerHTML = `
+    <div class="title-bar">
+      <div class="control close"></div>
+      <div class="control minimize"></div>
+      <div class="control maximize"></div>
+      <span class="title">${appName}</span>
+    </div>
+    <div class="content">${appName} window</div>
+  `;
+  const close = win.querySelector('.close');
+  close.addEventListener('click', () => win.remove());
+  makeDraggable(win, win.querySelector('.title-bar'));
+  return win;
+}
+
+// Drag desktop icons
+const desktopIcons = document.querySelectorAll('.desktop-icon');
+desktopIcons.forEach(icon => {
+  icon.addEventListener('dragstart', (e) => {
+    e.dataTransfer.setData('text/plain', null);
+  });
+});
+
+document.getElementById('desktop').addEventListener('dragover', (e) => {
+  e.preventDefault();
+});
+
+document.getElementById('desktop').addEventListener('drop', (e) => {
+  e.preventDefault();
+  const icon = document.querySelector('.desktop-icon.dragging');
+  if (icon) {
+    icon.style.position = 'absolute';
+    icon.style.left = e.clientX + 'px';
+    icon.style.top = e.clientY + 'px';
+  }
+});
+
+desktopIcons.forEach(icon => {
+  icon.addEventListener('dragstart', () => icon.classList.add('dragging'));
+  icon.addEventListener('dragend', () => icon.classList.remove('dragging'));
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,184 @@
+/* Global styles */
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+    user-select: none;
+    overflow: hidden;
+}
+
+#desktop {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    background: linear-gradient(120deg, #1e3c72, #2a5298);
+    background-size: cover;
+    color: #fff;
+}
+
+/* Menu bar */
+#menu-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 28px;
+    background: rgba(0,0,0,0.4);
+    backdrop-filter: blur(10px);
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    z-index: 1000;
+    font-size: 14px;
+}
+
+#menu-bar .menu-item {
+    margin-right: 10px;
+    cursor: default;
+}
+
+#menu-items span {
+    margin: 0 4px;
+}
+
+#status-items {
+    margin-left: auto;
+}
+
+.status-icon {
+    margin: 0 4px;
+    cursor: pointer;
+}
+
+/* Desktop icons */
+#icons {
+    position: absolute;
+    top: 60px;
+    left: 20px;
+}
+.desktop-icon {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 20px;
+    width: 80px;
+    color: white;
+    cursor: pointer;
+}
+.desktop-icon span {
+    margin-top: 4px;
+    text-shadow: 0 0 3px #000;
+}
+
+/* Dock */
+#dock {
+    position: fixed;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    height: 80px;
+    background: rgba(0,0,0,0.3);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    display: flex;
+    align-items: flex-end;
+    padding: 10px;
+    z-index: 1000;
+}
+.dock-icon {
+    font-size: 32px;
+    margin: 0 8px;
+    transition: transform 0.2s;
+    cursor: pointer;
+}
+.dock-icon:hover {
+    transform: scale(1.5);
+}
+
+/* Dropdown */
+.dropdown {
+    position: absolute;
+    top: 28px;
+    left: 5px;
+    background: rgba(50,50,50,0.9);
+    padding: 10px;
+    border-radius: 8px;
+    backdrop-filter: blur(8px);
+    color: white;
+}
+.dropdown ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.dropdown li {
+    padding: 4px 20px 4px 10px;
+    cursor: pointer;
+}
+.dropdown li:hover {
+    background: rgba(255,255,255,0.2);
+}
+
+.hidden {
+    display: none;
+}
+
+/* Windows */
+.window {
+    position: absolute;
+    top: 120px;
+    left: 50px;
+    width: 300px;
+    background: rgba(255,255,255,0.8);
+    backdrop-filter: blur(20px);
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+    color: black;
+}
+.title-bar {
+    display: flex;
+    align-items: center;
+    height: 24px;
+    padding: 0 8px;
+    background: rgba(0,0,0,0.1);
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    cursor: move;
+}
+.control {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin-right: 6px;
+}
+.control.close { background: #ff5f57; }
+.control.minimize { background: #ffbd2e; }
+.control.maximize { background: #28c840; }
+.title {
+    margin-left: 10px;
+    font-weight: bold;
+}
+.content {
+    padding: 10px;
+}
+
+/* Overlays */
+.overlay {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255,255,255,0.9);
+    backdrop-filter: blur(15px);
+    padding: 20px;
+    border-radius: 12px;
+    color: black;
+    z-index: 2000;
+}
+#spotlight-search input {
+    width: 300px;
+    padding: 8px;
+    font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- add simple macOS Sonoma desktop simulation using pure HTML/CSS/JS
- implement menu bar, dock with magnification, sample draggable windows
- provide basic overlays for Spotlight, Control Center and Notification Center
- replace broken README with instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fd2496d548332b1267add99b97171